### PR TITLE
get rid of warnings

### DIFF
--- a/libSegFault/alpha/register-dump.h
+++ b/libSegFault/alpha/register-dump.h
@@ -229,7 +229,7 @@ static void register_dump(int fd, struct ucontext_t *ctx)
     ADD_STRING("\n");
 
     /* Write the stuff out.  */
-    writev(fd, iov, nr);
+    ssize_t c = writev(fd, iov, nr);
 }
 
 #define REGISTER_DUMP register_dump(fd, ctx)

--- a/libSegFault/x86_64/register-dump.h
+++ b/libSegFault/x86_64/register-dump.h
@@ -315,7 +315,7 @@ static void register_dump(int fd, ucontext_t *ctx)
     ADD_STRING("\n");
 
     /* Write the stuff out.  */
-    writev(fd, iov, nr);
+    ssize_t c = writev(fd, iov, nr);
 }
 
 


### PR DESCRIPTION
As a PR so we can review later in case we needed some of the return values after all.